### PR TITLE
Usuwa przykład geoRglm z 2.1.2 (pakiety)

### DIFF
--- a/02-r-a-dane-przestrzenne.Rmd
+++ b/02-r-a-dane-przestrzenne.Rmd
@@ -24,7 +24,7 @@ R zawiera także wiele funkcji pozwalających na przetwarzanie, wizualizację i 
 Zawarte są one w szeregu pakietów (zbiorów funkcji), między innymi:
 
 - Obsługa danych przestrzennych - **sf**, **stars**, **raster**, **terra**, **sp**, **rgdal**, **rgeos**
-- Geostatystyka - **gstat**, **geoR**, **geoRglm**
+- Geostatystyka - **gstat**, **geoR**
 
 Więcej szczegółów na ten temat pakietów R służących do analizy przestrzennej można znaleźć pod adresem https://cran.r-project.org/web/views/Spatial.html.
 


### PR DESCRIPTION
Na zajęciach pojawiła sie prośba do mnie więc spełniam.
Pakiet ponoć nie działa na najnowszej wersji R według Adama. Osobiście nie testowałem.

Patryk